### PR TITLE
Allow Colours to be user configurable

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -78,6 +78,7 @@ func main() {
 
 	// Initialise the Gui / Tui
 	gui := gui.New(db)
+	gui.ProcessColors(cfg.Colors)
 
 	if err := gui.Start(); err != nil {
 		log.Fatalf("main: Cannot start tui: %s", err)

--- a/internal/gui/cavers.go
+++ b/internal/gui/cavers.go
@@ -71,25 +71,25 @@ func (c *cavers) setEntries(g *Gui) {
 			Text:            header,
 			NotSelectable:   true,
 			Align:           tview.AlignLeft,
-			Color:           tcell.ColorWhite,
-			BackgroundColor: tcell.ColorDefault,
+			Color:           tview.Styles.PrimaryTextColor,
+			BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
 			Attributes:      tcell.AttrBold,
 		})
 	}
 
 	for i, caver := range g.state.resources.people {
 		table.SetCell(i+1, 0, tview.NewTableCell(caver.Name).
-			SetTextColor(tcell.ColorWhite).
+			SetTextColor(tview.Styles.PrimaryTextColor).
 			SetMaxWidth(30).
 			SetExpansion(1))
 
 		table.SetCell(i+1, 1, tview.NewTableCell(caver.Club).
-			SetTextColor(tcell.ColorWhite).
+			SetTextColor(tview.Styles.PrimaryTextColor).
 			SetMaxWidth(0).
 			SetExpansion(1))
 
 		table.SetCell(i+1, 2, tview.NewTableCell(strconv.FormatInt(caver.Count, 10)).
-			SetTextColor(tcell.ColorWhite).
+			SetTextColor(tview.Styles.PrimaryTextColor).
 			SetMaxWidth(0).
 			SetExpansion(1))
 	}

--- a/internal/gui/caves.go
+++ b/internal/gui/caves.go
@@ -62,7 +62,7 @@ func (c *caves) entries(g *Gui) {
 		return
 	}
 
-	g.state.resources.locations = caves	
+	g.state.resources.locations = caves
 }
 
 func (c *caves) setEntries(g *Gui) {
@@ -82,35 +82,35 @@ func (c *caves) setEntries(g *Gui) {
 			Text:            header,
 			NotSelectable:   true,
 			Align:           tview.AlignLeft,
-			Color:           tcell.ColorWhite,
-			BackgroundColor: tcell.ColorDefault,
+			Color:           tview.Styles.PrimaryTextColor,
+			BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
 			Attributes:      tcell.AttrBold,
 		})
 	}
 
 	for i, cave := range g.state.resources.locations {
 		table.SetCell(i+1, 0, tview.NewTableCell(cave.Name).
-			SetTextColor(tcell.ColorWhite).
+			SetTextColor(tview.Styles.PrimaryTextColor).
 			SetMaxWidth(30).
 			SetExpansion(1))
 
 		table.SetCell(i+1, 1, tview.NewTableCell(cave.Region).
-			SetTextColor(tcell.ColorWhite).
+			SetTextColor(tview.Styles.PrimaryTextColor).
 			SetMaxWidth(30).
 			SetExpansion(1))
 
 		table.SetCell(i+1, 2, tview.NewTableCell(cave.Country).
-			SetTextColor(tcell.ColorWhite).
+			SetTextColor(tview.Styles.PrimaryTextColor).
 			SetMaxWidth(0).
 			SetExpansion(1))
 
 		table.SetCell(i+1, 3, tview.NewTableCell(strconv.FormatBool(cave.SRT)).
-			SetTextColor(tcell.ColorWhite).
+			SetTextColor(tview.Styles.PrimaryTextColor).
 			SetMaxWidth(0).
 			SetExpansion(1))
 
 		table.SetCell(i+1, 4, tview.NewTableCell(strconv.FormatInt(cave.Visits, 10)).
-			SetTextColor(tcell.ColorWhite).
+			SetTextColor(tview.Styles.PrimaryTextColor).
 			SetMaxWidth(0).
 			SetExpansion(1))
 	}

--- a/internal/gui/gui.go
+++ b/internal/gui/gui.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/rivo/tview"
+	"github.com/gdamore/tcell"
 
 	"github.com/idlephysicist/cave-logger/internal/db"
 	"github.com/idlephysicist/cave-logger/internal/model"
@@ -38,10 +39,10 @@ func newState() *state {
 }
 
 type Gui struct {
-	app   *tview.Application
-	pages *tview.Pages
-	state *state
-	db    *db.Database
+	app    *tview.Application
+	pages  *tview.Pages
+	state  *state
+	db     *db.Database
 	//statsLocations *statsLocations
 }
 
@@ -51,6 +52,38 @@ func New(db *db.Database) *Gui {
 		pages: tview.NewPages(),
 		state: newState(),
 		db: db,
+	}
+}
+
+func (g *Gui) ProcessColors(colors map[string]string) {
+	for color, hex := range colors {
+		if hex == "" {
+			continue
+		}
+		switch color {
+		case "primitiveBackground":
+			tview.Styles.PrimitiveBackgroundColor = tcell.GetColor(hex)
+		case "contrastBackground":
+			tview.Styles.ContrastBackgroundColor = tcell.GetColor(hex)
+		case "moreContrastBackground":
+			tview.Styles.MoreContrastBackgroundColor = tcell.GetColor(hex)
+		case "border":
+			tview.Styles.BorderColor = tcell.GetColor(hex)
+		case "title":
+			tview.Styles.TitleColor = tcell.GetColor(hex)
+		case "graphics":
+			tview.Styles.GraphicsColor = tcell.GetColor(hex)
+		case "primaryText":
+			tview.Styles.PrimaryTextColor = tcell.GetColor(hex)
+		case "secondaryText":
+			tview.Styles.SecondaryTextColor = tcell.GetColor(hex)
+		case "tertiaryText":
+			tview.Styles.TertiaryTextColor = tcell.GetColor(hex)
+		case "inverseText":
+			tview.Styles.InverseTextColor = tcell.GetColor(hex)
+		case "contrastSecondaryText":
+			tview.Styles.ContrastSecondaryTextColor = tcell.GetColor(hex)
+		}
 	}
 }
 
@@ -144,11 +177,11 @@ func (g *Gui) initPanels() {
 
 	// Add pages to the "book"
 	g.pages.AddPage(`trips`, trips, true, true)
-	fmt.Fprintf(g.state.tabBar, `  ["%d"]%d %s[white][""] `, 0, 1, strings.Title(trips.name()))
+	fmt.Fprintf(g.state.tabBar, `  ["%d"]%d %s[""] `, 0, 1, strings.Title(trips.name()))
 	g.pages.AddPage(`cavers`, cavers, true, true)
-	fmt.Fprintf(g.state.tabBar, `  ["%d"]%d %s[white][""] `, 1, 2, strings.Title(cavers.name()))
+	fmt.Fprintf(g.state.tabBar, `  ["%d"]%d %s[""] `, 1, 2, strings.Title(cavers.name()))
 	g.pages.AddPage(`caves`, caves, true, true)
-	fmt.Fprintf(g.state.tabBar, `  ["%d"]%d %s[white][""] `, 2, 3, strings.Title(caves.name()))
+	fmt.Fprintf(g.state.tabBar, `  ["%d"]%d %s[""] `, 2, 3, strings.Title(caves.name()))
 
 	g.state.tabBar.Highlight("0")
 
@@ -271,3 +304,4 @@ func (g *Gui) selectedPerson() *model.Caver {
 
 	return g.state.resources.people[row-1]
 }
+

--- a/internal/gui/navigate.go
+++ b/internal/gui/navigate.go
@@ -1,9 +1,6 @@
 package gui
 
-import (
-	"github.com/gdamore/tcell"
-	"github.com/rivo/tview"
-)
+import "github.com/rivo/tview"
 
 type navigate struct {
 	*tview.TextView
@@ -12,7 +9,7 @@ type navigate struct {
 
 func newNavigate() *navigate {
 	navi := &navigate{
-		TextView: tview.NewTextView().SetTextColor(tcell.ColorWhite),
+		TextView: tview.NewTextView().SetTextColor(tview.Styles.PrimaryTextColor),
 		keybindings: map[string]string{
 			"trips" : " n: New Log Entry, m: Modify Log,  d: Remove Log, /: filter, Enter: Inspect ",
 			"caves" : " n: New Cave, m: Modify Cave, d: Remove Cave, /: filter, Enter: Inspect ",

--- a/internal/gui/trips.go
+++ b/internal/gui/trips.go
@@ -80,25 +80,25 @@ func (t *trips) setEntries(g *Gui) {
 			Text:            header,
 			NotSelectable:   true,
 			Align:           tview.AlignLeft,
-			Color:           tcell.ColorWhite,
-			BackgroundColor: tcell.ColorDefault,
+			Color:           tview.Styles.PrimaryTextColor,
+			BackgroundColor: tview.Styles.PrimitiveBackgroundColor,
 			Attributes:      tcell.AttrBold,
 		})
 	}
 
 	for i, trip := range g.state.resources.trips {
 		table.SetCell(i+1, 0, tview.NewTableCell(trip.Date).
-			SetTextColor(tcell.ColorWhite).
+			SetTextColor(tview.Styles.PrimaryTextColor).
 			SetMaxWidth(30).
 			SetExpansion(1))
 
 		table.SetCell(i+1, 1, tview.NewTableCell(trip.Cave).
-			SetTextColor(tcell.ColorWhite).
+			SetTextColor(tview.Styles.PrimaryTextColor).
 			SetMaxWidth(30).
 			SetExpansion(1))
 
 		table.SetCell(i+1, 2, tview.NewTableCell(trip.Names).
-			SetTextColor(tcell.ColorWhite).
+			SetTextColor(tview.Styles.PrimaryTextColor).
 			SetMaxWidth(0).
 			SetExpansion(2))
 	}

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -5,5 +5,6 @@ type Config struct {
 		Created string `json:"created"`
 		Filename string `json:"filename"`
 	} `json:"database"`
+	Colors map[string]string `json:"colors"`
 }
 

--- a/scripts/make-db.py
+++ b/scripts/make-db.py
@@ -93,6 +93,19 @@ with open(CONFIG_FN, 'w') as c:
     'database': {
       'filename': '/'.join([NEWPATH, sqliteFile]),
       'created' : NOW
+    },
+    'colors': {
+      'primitiveBackground': '',
+      'contrastBackground': '',
+      'moreContrastBackground': '',
+      'border': '',
+      'title': '',
+      'graphics': '',
+      'primaryText': '',
+      'secondaryText': '',
+      'tertiaryText': '',
+      'inverseText': '',
+      'contrastSecondaryText': ''
     }
   }
   json.dump(config, c)


### PR DESCRIPTION
The Go code now reads hex colour codes from the JSON config file.

If a colour parameter is left as an empty string in the JSON file the `tview` default colour will be used. The default `tview` theme can be found in the documentation under "pkg-variables" ([here](https://pkg.go.dev/github.com/rivo/tview?tab=doc#pkg-variables))

TODO:
- [x] Update the Python scripts which generate the config file