### PR TITLE
Feature filter rows by inequality. (#36)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ _old
 # Mac
 *.DS_Store
 
+tags
 
 # -- Except ----
 !.keep

--- a/internal/gui/cavers.go
+++ b/internal/gui/cavers.go
@@ -13,8 +13,8 @@ import (
 
 type cavers struct {
 	*tview.Table
-	cavers                chan *model.Caver
-	filterCol, filterTerm string
+	cavers                              chan *model.Caver
+	filterCol, filterTerm, filterAction string
 }
 
 func newCavers(g *Gui) *cavers {
@@ -138,9 +138,10 @@ func (c *cavers) unfocus() {
 	c.SetSelectable(false, false)
 }
 
-func (c *cavers) setFilter(col, term string) {
+func (c *cavers) setFilter(col, term, action string) {
 	c.filterCol = col
 	c.filterTerm = term
+	c.filterAction = action
 }
 
 func (c *cavers) monitoringCavers(g *Gui) {
@@ -173,8 +174,10 @@ func (g *Gui) uniqueClubs(input []*model.Caver) []string {
 }
 
 func (c *cavers) search(caver *model.Caver) bool {
+	// Below *looks* goofy but it all makes sense considering this funciton
+	// needs to return false normally!!
 	switch c.filterCol {
-	case "name", "":
+	case "name":
 		if strings.Index(strings.ToLower(caver.Name), c.filterTerm) == -1 {
 			return true
 		}
@@ -184,6 +187,15 @@ func (c *cavers) search(caver *model.Caver) bool {
 			return true
 		}
 		return false
+	case "count", "":
+		switch c.filterAction {
+		case "<":
+			return caver.Count > atoi(c.filterTerm)
+		case ">":
+			return caver.Count < atoi(c.filterTerm)
+		default:
+			return false
+		}
 	default:
 		return false
 	}

--- a/internal/gui/caves.go
+++ b/internal/gui/caves.go
@@ -13,8 +13,8 @@ import (
 
 type caves struct {
 	*tview.Table
-	caves                 chan *model.Cave
-	filterCol, filterTerm string
+	caves                               chan *model.Cave
+	filterCol, filterTerm, filterAction string
 }
 
 func newCaves(g *Gui) *caves {
@@ -150,9 +150,10 @@ func (c *caves) unfocus() {
 	c.SetSelectable(false, false)
 }
 
-func (c *caves) setFilter(col, term string) {
+func (c *caves) setFilter(col, term, action string) {
 	c.filterCol = col
 	c.filterTerm = term
+	c.filterAction = action
 }
 
 func (c *caves) monitoringCaves(g *Gui) {
@@ -207,8 +208,10 @@ func yesOrNo(val bool) string {
 }
 
 func (c *caves) search(cave *model.Cave) bool {
+	// Below *looks* goofy but it all makes sense considering this funciton
+	// needs to return false normally!!
 	switch c.filterCol {
-	case "name", "":
+	case "name":
 		if strings.Index(strings.ToLower(cave.Name), c.filterTerm) == -1 {
 			return true
 		}
@@ -223,6 +226,15 @@ func (c *caves) search(cave *model.Cave) bool {
 			return true
 		}
 		return false
+	case "visits", "":
+		switch c.filterAction {
+		case "<":
+			return cave.Visits > atoi(c.filterTerm)
+		case ">":
+			return cave.Visits < atoi(c.filterTerm)
+		default:
+			return false
+		}
 	default:
 		return false
 	}

--- a/internal/gui/keybindings.go
+++ b/internal/gui/keybindings.go
@@ -1,6 +1,7 @@
 package gui
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/gdamore/tcell/v2"
@@ -29,7 +30,7 @@ func (g *Gui) setGlobalKeybinding(event *tcell.EventKey) {
 
 func (g *Gui) filter() {
 	currentPanel := g.state.panels.panel[g.state.panels.currentPanel]
-	currentPanel.setFilter("", "")
+	currentPanel.setFilter("", "", "")
 	currentPanel.updateEntries(g)
 
 	viewName := "filter"
@@ -61,7 +62,21 @@ func (g *Gui) filter() {
 			textSl := strings.Split(strings.ToLower(text), "/")
 
 			if len(textSl) == 2 {
-				currentPanel.setFilter(textSl[0], textSl[1])
+				currentPanel.setFilter(textSl[0], textSl[1], "")
+				currentPanel.updateEntries(g)
+			}
+		} else if strings.Contains(text, "<") {
+			textSl := strings.Split(strings.ToLower(text), "<")
+
+			if len(textSl) == 2 {
+				currentPanel.setFilter(textSl[0], textSl[1], "<")
+				currentPanel.updateEntries(g)
+			}
+		} else if strings.Contains(text, ">") {
+			textSl := strings.Split(strings.ToLower(text), ">")
+
+			if len(textSl) == 2 {
+				currentPanel.setFilter(textSl[0], textSl[1], ">")
 				currentPanel.updateEntries(g)
 			}
 		}
@@ -95,3 +110,11 @@ func (g *Gui) nextPage() {
 	g.goTo(g.selectPage(slide - 1, 0)) // NOTE: If the Highlight func is fixed for the tab bar then this line will not be required
 }
 */
+
+func atoi(s string) int64 {
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}

--- a/internal/gui/panel.go
+++ b/internal/gui/panel.go
@@ -8,5 +8,5 @@ type panel interface {
 	setKeybinding(*Gui)
 	focus(*Gui)
 	unfocus()
-	setFilter(string, string)
+	setFilter(string, string, string)
 }

--- a/internal/gui/trips.go
+++ b/internal/gui/trips.go
@@ -12,8 +12,8 @@ import (
 
 type trips struct {
 	*tview.Table
-	trips                 chan *model.Log
-	filterCol, filterTerm string
+	trips                               chan *model.Log
+	filterCol, filterTerm, filterAction string
 }
 
 func newTrips(g *Gui) *trips {
@@ -132,9 +132,10 @@ func (t *trips) unfocus() {
 	t.SetSelectable(false, false)
 }
 
-func (t *trips) setFilter(col, term string) {
+func (t *trips) setFilter(col, term, action string) {
 	t.filterCol = col
 	t.filterTerm = term
+	t.filterAction = action // Unused in this window.
 }
 
 func (t *trips) monitoringTrips(g *Gui) {
@@ -153,6 +154,8 @@ LOOP:
 }
 
 func (t *trips) search(trip *model.Log) bool {
+	// Below *looks* goofy but it all makes sense considering this funciton
+	// needs to return false normally!!
 	switch t.filterCol {
 	case "cave", "":
 		if strings.Index(strings.ToLower(trip.Cave), t.filterTerm) == -1 {


### PR DESCRIPTION
Allows rudimentary filtering of rows using inequalities, in Caves &
Cavers, on columns Views & Count respectively.

Added comments to `search` methods that attempt point out the goofy
nature of that function, i.e. that it needs to return `false`
generally, and that we only return `true` if there is something we
want to _not_ display there by only displaying what matches our
search criteria. Not sure exactly why I wrote it that way.

Updated .gitignore to exclude tags file.

NB: Change in functionality — Applying a filter with no column specified
now assumes you are looking at `visits` or `count`.